### PR TITLE
fix: icons cache, rounding, default trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ git clone https://github.com/DenverCoder1/unit-converter-albert-ext.git
 ```bash
 cd unit-converter-albert-ext
 
-pip install -r requirements.txt -t ~/.local/share/albert/python/site-packages
+pip install -U -r requirements.txt -t ~/.local/share/albert/python/site-packages
 ```
 
 4. Enable the extension in the settings under `Extensions > Python`.
@@ -42,25 +42,35 @@ pip install -r requirements.txt -t ~/.local/share/albert/python/site-packages
 
 ## Usage
 
-Type an amount and unit, followed by the word "to" or "in" and then the unit you want to convert to.
+Type the trigger, followed by the amount and unit, the word "to" or "in", and then the unit you want to convert to.
 
-`<from_amount> <from_unit> {to|in} <to_unit>`
+`convert <amount> <from_unit> {to|in} <to_unit>`
 
 Examples:
 
-`180 minutes to hrs`
+`convert 180 minutes to hrs`
 
-`100 km in miles`
+`convert 100 km to miles`
 
-`88 mph in kph`
+`convert 88 mph to kph`
 
-`32 degrees F to C`
+`convert 32 degrees F to C`
 
-`3.14159 rad to degrees`
+`convert 3.14159 rad to degrees`
+
+To configure the trigger to be something other than "convert ", open the `Triggers` tab in the Albert settings.
+
+![image](https://user-images.githubusercontent.com/20955511/211632106-981ce5a8-0311-47d5-aefe-3ab9d669fc3f.png)
 
 ## Configuration
 
-In `config.jsonc` there are options to customize the extension:
+In `config.jsonc` there are options to customize the behavior of the extension:
+
+### Rounding Precision
+
+The `rounding_precision` option controls how many decimal places the result will be rounded to. By default, this is 3.
+
+The `rounding_precision_zero` option controls how many decimal places the result will be rounded to when the result is close to zero. By default, this is 12.
 
 ### Aliases
 

--- a/__init__.py
+++ b/__init__.py
@@ -6,27 +6,31 @@ import json
 import re
 import traceback
 from pathlib import Path
+from typing import Any
 
 import albert
 import pint
 import inflect
 
-__doc__ = """
+default_trigger = "convert "
+synopsis = "<amount> <from_unit> to <to_unit>"
+
+__doc__ = f"""
 Extension for converting units of length, mass, speed, temperature, time,
 current, luminosity, printing measurements, molecular substance, and more
 
-Synopsis: `<from_amount> <from_unit> {to|in} <to_unit>`
+Synopsis: {default_trigger}{synopsis}
 
 Examples:
-`180 minutes to hrs`
-`100 km in miles`
-`88 mph in kph`
-`32 degrees F to C`
-`3.14159 rad to degrees`
+`{default_trigger}180 minutes to hrs`
+`{default_trigger}100 km to miles`
+`{default_trigger}88 mph to kph`
+`{default_trigger}32 degrees F to C`
+`{default_trigger}3.14159 rad to degrees`
 """
 
 md_iid = "0.5"
-md_version = "1.0"
+md_version = "1.1"
 md_name = "Unit Converter"
 md_description = "Convert length, mass, speed, temperature, time, and more"
 md_license = "MIT"
@@ -43,7 +47,7 @@ units = pint.UnitRegistry()
 inflect_engine = inflect.engine()
 
 
-def load_config(config_path: Path) -> dict[str, dict[str, str]]:
+def load_config(config_path: Path) -> dict[str, Any]:
     """
     Strip comments and load the config from the config file.
     """
@@ -84,6 +88,8 @@ class ConversionResult:
         self.to_unit = to_unit
         self.dimensionality = units._get_dimensionality(to_unit)
         self.display_names = config.get("display_names", {})
+        self.rounding_precision = int(config.get("rounding_precision", 3))
+        self.rounding_precision_zero = int(config.get("rounding_precision_zero", 12))
 
     def __pluralize_unit(self, unit: pint.Unit) -> str:
         """
@@ -110,17 +116,28 @@ class ConversionResult:
         unit = self.__pluralize_unit(unit) if amount != 1 else str(unit)
         return self.display_names.get(unit, unit)
 
-    def __round_or_truncate(self, num: float) -> float | int:
+    def __format_float(self, num: float) -> str:
         """
-        Round floating point number to 2 decimal places or convert to an integer if ends with .0
+        Format a float to remove trailing zeros and avoid scientific notation
 
         Args:
-            num (float): The number to round
+            num (float): The number to format
 
         Returns:
-            Union[float, int]: The rounded number
+            str: The formatted number
         """
-        return round(num, 2) if num % 1 else int(num)
+        # if rounding precision is -1, leave as is
+        if self.rounding_precision == -1:
+            return str(num)
+        # round to the given rounding precision
+        rounded = round(num, self.rounding_precision)
+        # if it is close to zero, round to the given precision for zero
+        if rounded == 0 and self.rounding_precision_zero > 0:
+            zero_delta = 1 / 10 ** self.rounding_precision_zero
+            if abs(num) > zero_delta:
+                rounded = round(num, self.rounding_precision_zero)
+        # format the float to remove trailing zeros and decimal point
+        return f"{rounded:f}".rstrip("0").rstrip(".")
 
     @property
     def formatted_result(self) -> str:
@@ -128,7 +145,7 @@ class ConversionResult:
         Return the formatted result amount and unit
         """
         units = self.__display_unit_name(self.to_amount, self.to_unit)
-        return f"{self.__round_or_truncate(float(self.to_amount))} {units}"
+        return f"{self.__format_float(self.to_amount)} {units}"
 
     @property
     def formatted_from(self) -> str:
@@ -136,7 +153,7 @@ class ConversionResult:
         Return the formatted from amount and unit
         """
         units = self.__display_unit_name(self.from_amount, self.from_unit)
-        return f"{self.__round_or_truncate(float(self.from_amount))} {units}"
+        return f"{self.__format_float(self.from_amount)} {units}"
 
     @property
     def icon(self) -> str:
@@ -222,10 +239,10 @@ class Plugin(albert.QueryHandler):
         return md_description
 
     def synopsis(self) -> str:
-        return "<from_amount> <from_unit> {to|in} <to_unit>" if self.defaultTrigger() else ""
+        return synopsis
 
     def defaultTrigger(self) -> str:
-        return ""
+        return default_trigger
 
     def handleQuery(self, query: albert.Query) -> None:
         """Handler for a query received from Albert."""
@@ -265,7 +282,7 @@ class Plugin(albert.QueryHandler):
             albert.warning(f"Icon {icon} does not exist")
             icon_path = Path(__file__).parent / "icons" / "unit_converter.svg"
         return albert.Item(
-            id=self.name(),
+            id=str(icon_path),
             icon=[str(icon_path)],
             text=text,
             subtext=subtext,

--- a/config.jsonc
+++ b/config.jsonc
@@ -1,4 +1,14 @@
 {
+    // Number of decimal places to round to
+    //
+    // If specified as -1, the number will not be manually rounded
+    "rounding_precision": 3,
+
+    // Number of decimal places to round to when the result is close to zero
+    //
+    // If specified as -1, the number will not be manually rounded
+    "rounding_precision_zero": 12,
+
     // Unit aliases to replace when parsing
     //
     // Units may be added here to override the default behavior or create aliases for existing units


### PR DESCRIPTION
Each unit type and conversion errors will show different icons and not use cached single icon

Rounding is now configurable. Close to zero numbers will have more precision by default.

Fixes #3 

Default trigger is "convert " it can be configured in the Triggers tab in the albert launcher settings.